### PR TITLE
Typo in corpus reader how to

### DIFF
--- a/howto/corpus.html
+++ b/howto/corpus.html
@@ -1718,7 +1718,7 @@ reader for it with:</p>
 ...     '/usr/share/some-corpus', '.*\.txt') # doctest: +SKIP
 </pre>
 <p>For a complete list of corpus reader subclasses, see the API
-documentation for <cite>nltk.corpus.CorpusReader</cite>.</p>
+documentation for <cite>nltk.corpus.reader</cite>.</p>
 </div>
 <div class="section" id="corpus-types">
 <h2>Corpus Types</h2>


### PR DESCRIPTION
As mentioned in https://github.com/nltk/nltk.github.com/issues/2