### PR TITLE
Documentation Typo in nltk.tag.stanford

### DIFF
--- a/api/nltk.tag.html
+++ b/api/nltk.tag.html
@@ -2100,7 +2100,7 @@ list of paths).</p>
 <ul class="simple">
 <li>a model trained on training data</li>
 <li>(optionally) the path to the stanford tagger jar file. If not specified here,
-then this jar file must be specified in the CLASSPATH envinroment variable.</li>
+then this jar file must be specified in the CLASSPATH environment variable.</li>
 <li>(optionally) the encoding of the training data (default: UTF-8)</li>
 </ul>
 <p>Example:</p>


### PR DESCRIPTION
Corrected "envinroment" to "environment".