### PR TITLE
Fix typo in about nltk section

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@ introduction to programming for language processing.
 Written by the creators of NLTK, it guides the reader through the fundamentals
 of writing Python programs, working with corpora, categorizing text, analyzing linguistic structure,
 and more.
-The online version of the book has been been updated for Python 3 and NLTK 3.
+The online version of the book has been updated for Python 3 and NLTK 3.
 (The original Python 2 version is still available at <a class="reference external" href="http://nltk.org/book_1ed">http://nltk.org/book_1ed</a>.)</p>
 <div class="section" id="some-simple-things-you-can-do-with-nltk">
 <h2>Some simple things you can do with NLTK<a class="headerlink" href="#some-simple-things-you-can-do-with-nltk" title="Permalink to this headline">¶</a></h2>


### PR DESCRIPTION
Delete double been in about natural-language-toolkit section.