### PR TITLE
Fix links to nltk book

### DIFF
--- a/_modules/nltk/__init__.html
+++ b/_modules/nltk/__init__.html
@@ -52,7 +52,7 @@
 
 <span class="sd">Steven Bird, Ewan Klein, and Edward Loper (2009).</span>
 <span class="sd">Natural Language Processing with Python.  O&#39;Reilly Media Inc.</span>
-<span class="sd">http://nltk.org/book</span>
+<span class="sd">http://nltk.org/book/</span>
 <span class="sd">&quot;&quot;&quot;</span>
 
 <span class="kn">import</span> <span class="nn">os</span>

--- a/_sources/index.txt
+++ b/_sources/index.txt
@@ -15,7 +15,7 @@ NLTK is available for Windows, Mac OS X, and Linux. Best of all, NLTK is a free,
 NLTK has been called "a wonderful tool for teaching, and working in, computational linguistics using Python,"
 and "an amazing library to play with natural language."
 
-`Natural Language Processing with Python <http://nltk.org/book>`_ provides a practical
+`Natural Language Processing with Python <http://nltk.org/book/>`_ provides a practical
 introduction to programming for language processing.
 Written by the creators of NLTK, it guides the reader through the fundamentals
 of writing Python programs, working with corpora, categorizing text, analyzing linguistic structure,

--- a/_sources/news.txt
+++ b/_sources/news.txt
@@ -62,7 +62,7 @@ NLTK 3.0.0b2 released : August 2014
    Minor bugfixes and clean-ups.
 
 NLTK Book Updates : July 2014
-   The NLTK book is being updated for Python 3 and NLTK 3 `here <http://nltk.org/book>`_.
+   The NLTK book is being updated for Python 3 and NLTK 3 `here <http://nltk.org/book/>`_.
    The original Python 2 edition is still available `here <http://nltk.org/book_1ed>`_.
 
 NLTK 3.0.0b1 released : July 2014

--- a/lib/nltk/__init__.py
+++ b/lib/nltk/__init__.py
@@ -13,7 +13,7 @@ for Natural Language Processing.  A free online book is available.
 
 Steven Bird, Ewan Klein, and Edward Loper (2009).
 Natural Language Processing with Python.  O'Reilly Media Inc.
-http://nltk.org/book
+http://nltk.org/book/
 
 isort:skip_file
 """

--- a/lib/nltk/test/portuguese_en.doctest
+++ b/lib/nltk/test/portuguese_en.doctest
@@ -7,7 +7,7 @@ Examples for Portuguese Processing
 
 This HOWTO contains a variety of examples relating to the Portuguese language.
 It is intended to be read in conjunction with the NLTK book
-(``http://nltk.org/book``).  For instructions on running the Python
+(``http://nltk.org/book/``).  For instructions on running the Python
 interpreter, please see the section *Getting Started with Python*, in Chapter 1.
 
 --------------------------------------------


### PR DESCRIPTION
Okay, this should _actually_ close https://github.com/nltk/nltk/issues/2891

As @tomaarsen helpfully pointed out, the issue are specifically links that look like:
- http://nltk.org/book
- https://nltk.org/book

So I'm fixing just those in our website