### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ wrappers for industrial-strength NLP libraries,
 and an active <a class="reference external" href="https://groups.google.com/group/nltk-users">discussion forum</a>.</p>
 <p>Thanks to a hands-on guide introducing programming fundamentals alongside topics in computational linguistics, plus comprehensive API documentation,
 NLTK is suitable for linguists, engineers, students, educators, researchers, and industry users alike.
-NLTK is available for Windows, Mac OS X, and Linux. Best of all, NLTK is a free, open source, community-driven project.</p>
+NLTK is available for Windows, macOS, and Linux. Best of all, NLTK is a free, open source, community-driven project.</p>
 <p>NLTK has been called “a wonderful tool for teaching, and working in, computational linguistics using Python,”
 and “an amazing library to play with natural language.”</p>
 <p><a class="reference external" href="https://www.nltk.org/book/">Natural Language Processing with Python</a> provides a practical

--- a/lib/nltk/classify/naivebayes.py
+++ b/lib/nltk/classify/naivebayes.py
@@ -43,7 +43,7 @@ from nltk.probability import DictionaryProbDist, ELEProbDist, FreqDist, sum_logs
 class NaiveBayesClassifier(ClassifierI):
     """
     A Naive Bayes classifier.  Naive Bayes classifiers are
-    paramaterized by two probability distributions:
+    parameterized by two probability distributions:
 
       - P(label) gives the probability that an input will receive each
         label, given no information about the input's features.

--- a/lib/nltk/classify/weka.py
+++ b/lib/nltk/classify/weka.py
@@ -1,4 +1,4 @@
-# Natural Language Toolkit: Interface to Weka Classsifiers
+# Natural Language Toolkit: Interface to Weka Classifiers
 #
 # Copyright (C) 2001-2023 NLTK Project
 # Author: Edward Loper <edloper@gmail.com>

--- a/lib/nltk/corpus/reader/categorized_sents.py
+++ b/lib/nltk/corpus/reader/categorized_sents.py
@@ -42,7 +42,7 @@ from nltk.tokenize import *
 class CategorizedSentencesCorpusReader(CategorizedCorpusReader, CorpusReader):
     """
     A reader for corpora in which each row represents a single instance, mainly
-    a sentence. Istances are divided into categories based on their file identifiers
+    a sentence. Instances are divided into categories based on their file identifiers
     (see CategorizedCorpusReader).
     Since many corpora allow rows that contain more than one sentence, it is
     possible to specify a sentence tokenizer to retrieve all sentences instead

--- a/lib/nltk/corpus/reader/reviews.py
+++ b/lib/nltk/corpus/reader/reviews.py
@@ -33,7 +33,7 @@ Related papers:
     Proceedings of Nineteeth National Conference on Artificial Intelligence
     (AAAI-2004), 2004.
 
-- Xiaowen Ding, Bing Liu and Philip S. Yu. "A Holistic Lexicon-Based Appraoch to
+- Xiaowen Ding, Bing Liu and Philip S. Yu. "A Holistic Lexicon-Based Approach to
     Opinion Mining." Proceedings of First ACM International Conference on Web
     Search and Data Mining (WSDM-2008), Feb 11-12, 2008, Stanford University,
     Stanford, California, USA.

--- a/lib/nltk/downloader.py
+++ b/lib/nltk/downloader.py
@@ -27,7 +27,7 @@ package that should be downloaded:
 
 NLTK also provides a number of \"package collections\", consisting of
 a group of related packages.  To download all packages in a
-colleciton, simply call ``download()`` with the collection's
+collection, simply call ``download()`` with the collection's
 identifier:
 
     >>> download('all-corpora') # doctest: +SKIP
@@ -1767,7 +1767,7 @@ class DownloaderGUI:
         # position right -- I'm not sure what the underlying cause is
         # though.  (This is on OS X w/ python 2.5)  The length of
         # delay that's necessary seems to depend on how fast the
-        # comptuer is. :-/
+        # computer is. :-/
         self.top.after(150, self._table._scrollbar.set, *self._table._mlb.yview())
         self.top.after(300, self._table._scrollbar.set, *self._table._mlb.yview())
 

--- a/lib/nltk/draw/cfg.py
+++ b/lib/nltk/draw/cfg.py
@@ -306,7 +306,7 @@ class CFGEditor:
 
         self._analyze()
 
-    #         # Add the producitons to the text widget, and colorize them.
+    #         # Add the productions to the text widget, and colorize them.
     #         prod_by_lhs = {}
     #         for prod in self._cfg.productions():
     #             if len(prod.rhs()) > 0:

--- a/lib/nltk/parse/shiftreduce.py
+++ b/lib/nltk/parse/shiftreduce.py
@@ -210,7 +210,7 @@ class ShiftReduceParser(ParserI):
         """
         # 1: just show shifts.
         # 2: show shifts & reduces
-        # 3: display which tokens & productions are shifed/reduced
+        # 3: display which tokens & productions are shifted/reduced
         self._trace = trace
 
     def _trace_stack(self, stack, remaining_text, marker=" "):

--- a/lib/nltk/probability.py
+++ b/lib/nltk/probability.py
@@ -351,7 +351,7 @@ class FreqDist(Counter):
         """
         return self.__class__(self)
 
-    # Mathematical operatiors
+    # Mathematical operators
 
     def __add__(self, other):
         """
@@ -1353,7 +1353,7 @@ class WittenBellProbDist(ProbDistI):
 #
 
 ##//////////////////////////////////////////////////////
-##  Simple Good-Turing Probablity Distributions
+##  Simple Good-Turing Probability Distributions
 ##//////////////////////////////////////////////////////
 
 

--- a/lib/nltk/sentiment/sentiment_analyzer.py
+++ b/lib/nltk/sentiment/sentiment_analyzer.py
@@ -102,7 +102,7 @@ class SentimentAnalyzer:
         :param top_n: number of best words/tokens to use, sorted by association
             measure.
         :param assoc_measure: bigram association measure to use as score function.
-        :param min_freq: the minimum number of occurrencies of bigrams to take
+        :param min_freq: the minimum number of occurrences of bigrams to take
             into consideration.
 
         :return: `top_n` ngrams scored by the given association measure.

--- a/lib/nltk/stem/cistem.py
+++ b/lib/nltk/stem/cistem.py
@@ -118,7 +118,7 @@ class Cistem(StemmerI):
         This method works very similarly to stem (:func:'cistem.stem'). The difference is that in
         addition to returning the stem, it also returns the rest that was removed at
         the end. To be able to return the stem unchanged so the stem and the rest
-        can be concatenated to form the original word, all subsitutions that altered
+        can be concatenated to form the original word, all substitutions that altered
         the stem in any other way than by removing letters at the end were left out.
 
         :param word: The word that is to be stemmed.

--- a/lib/nltk/tag/tnt.py
+++ b/lib/nltk/tag/tnt.py
@@ -7,7 +7,7 @@
 # For license information, see LICENSE.TXT
 
 """
-Implementation of 'TnT - A Statisical Part of Speech Tagger'
+Implementation of 'TnT - A Statistical Part of Speech Tagger'
 by Thorsten Brants
 
 https://aclanthology.org/A00-1031.pdf

--- a/lib/nltk/tbl/template.py
+++ b/lib/nltk/tbl/template.py
@@ -256,7 +256,7 @@ class Template(BrillTemplateI):
 
         #Templates where one feature is a subset of another, such as
         #Template(Word([0,1]), Word([1]), will not appear in the output.
-        #By default, this non-subset constraint is tightened to disjointness:
+        #By default, this non-subset constraint is tightened to disjointedness:
         #Templates of type Template(Word([0,1]), Word([1,2]) will also be filtered out.
         #With skipintersecting=False, then such Templates are allowed
 

--- a/lib/nltk/tokenize/nist.py
+++ b/lib/nltk/tokenize/nist.py
@@ -125,7 +125,7 @@ class NISTTokenizer(TokenizerI):
     INTERNATIONAL_REGEXES = [NONASCII, PUNCT_1, PUNCT_2, SYMBOLS]
 
     def lang_independent_sub(self, text):
-        """Performs the language independent string substituitions."""
+        """Performs the language independent string substitutions."""
         # It's a strange order of regexes.
         # It'll be better to unescape after STRIP_EOL_HYPHEN
         # but let's keep it close to the original NIST implementation.

--- a/lib/nltk/tokenize/stanford_segmenter.py
+++ b/lib/nltk/tokenize/stanford_segmenter.py
@@ -33,7 +33,7 @@ class StanfordSegmenter(TokenizerI):
     """Interface to the Stanford Segmenter
 
     If stanford-segmenter version is older than 2016-10-31, then path_to_slf4j
-    should be provieded, for example::
+    should be provided, for example::
 
         seg = StanfordSegmenter(path_to_slf4j='/YOUR_PATH/slf4j-api.jar')
 
@@ -233,7 +233,7 @@ class StanfordSegmenter(TokenizerI):
         # Create a temporary input file
         _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
 
-        # Write the actural sentences to the temporary input file
+        # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, "wb")
         _input = "\n".join(" ".join(x) for x in sentences)
         if isinstance(_input, str) and encoding:

--- a/lib/nltk/twitter/twitterclient.py
+++ b/lib/nltk/twitter/twitterclient.py
@@ -174,7 +174,7 @@ class Query(Twython):
     def _search_tweets(self, keywords, limit=100, lang="en"):
         """
         Assumes that the handler has been informed. Fetches Tweets from
-        search_tweets generator output and passses them to handler
+        search_tweets generator output and passes them to handler
 
         :param str keywords: A list of query terms to search for, written as\
         a comma-separated string.


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

Also,
```diff
- NLTK is available for Windows, Mac OS X, and Linux.
+ NLTK is available for Windows, macOS, and Linux.
```
https://www.apple.com/os/macos --> ___macOS v26___ -- The __X__ was for ___v10___ which went away long ago.